### PR TITLE
Fix package after replacer plugin and default values

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -85,7 +85,7 @@
                         </goals>
                         <configuration>
                             <file>${project.basedir}/templates/HTMLModels.java</file>
-                            <outputFile>${project.build.directory}/generated-sources/replacer/com/lafaspot/tagchowder/templates/HTMLModels.java</outputFile>
+                            <outputFile>${project.build.directory}/generated-sources/com/lafaspot/tagchowder/templates/HTMLModels.java</outputFile>
                             <regex>false</regex>
                             <token>@@MODEL_DEFINITIONS@@</token>
                             <valueFile>${project.build.directory}/generated-resources/xml/xslt/model/html.tssl</valueFile>
@@ -99,7 +99,7 @@
                         </goals>
                         <configuration>
                             <file>${project.basedir}/templates/HTMLSchema.java</file>
-                            <outputFile>${project.build.directory}/generated-sources/replacer/com/lafaspot/tagchowder/templates/HTMLSchema.java</outputFile>
+                            <outputFile>${project.build.directory}/generated-sources/com/lafaspot/tagchowder/templates/HTMLSchema.java</outputFile>
                             <regex>false</regex>
                             <token>@@SCHEMA_CALLS@@</token>
                             <valueFile>${project.build.directory}/generated-resources/xml/xslt/schema/html.tssl</valueFile>
@@ -113,7 +113,7 @@
                         </goals>
                         <configuration>
                             <file>${project.basedir}/templates/HTMLScanner.java</file>
-                            <outputFile>${project.build.directory}/generated-sources/replacer/com/lafaspot/tagchowder/templates/HTMLScanner.java</outputFile>
+                            <outputFile>${project.build.directory}/generated-sources/com/lafaspot/tagchowder/templates/HTMLScanner.java</outputFile>
                             <regex>false</regex>
                             <token>@@STATE_TABLE@@</token>
                             <valueFile>${project.build.directory}/generated-resources/xml/xslt/scanner/html.stml</valueFile>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.lafa.tagchowder</groupId>
         <artifactId>tagchowder</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
     </parent>
     <artifactId>tagchowder.core</artifactId>
     <name>${project.artifactId}</name>

--- a/core/src/main/java/com/lafaspot/tagchowder/Parser.java
+++ b/core/src/main/java/com/lafaspot/tagchowder/Parser.java
@@ -174,43 +174,43 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
     /**
      * A value of "true" indicates that the parser will ignore unknown elements.
      **/
-    public static final String IGNORE_BOGONS_FEATURE = "";
+    public static final String IGNORE_BOGONS_FEATURE = "ignore-bogons";
 
     /**
      * A value of "true" indicates that the parser will give unknown elements a content model of EMPTY; a value of "false", a content model of ANY.
      **/
-    public static final String BOGONS_EMPTY_FEATURE = "";
+    public static final String BOGONS_EMPTY_FEATURE = "bogons-empty";
 
     /**
      * A value of "true" indicates that the parser will allow unknown elements to be the root element.
      **/
-    public static final String ROOT_BOGONS_FEATURE = "";
+    public static final String ROOT_BOGONS_FEATURE = "root-bogons";
 
     /**
      * A value of "true" indicates that the parser will return default attribute values for missing attributes that have default values.
      **/
-    public static final String DEFAULT_ATTRIBUTES_FEATURE = "";
+    public static final String DEFAULT_ATTRIBUTES_FEATURE = "default-attributes";
 
     /**
      * A value of "true" indicates that the parser will translate colons into underscores in names.
      **/
-    public static final String TRANSLATE_COLONS_FEATURE = "";
+    public static final String TRANSLATE_COLONS_FEATURE = "translate-colons";
 
     /**
      * A value of "true" indicates that the parser will attempt to restart the restartable elements.
      **/
-    public static final String RESTART_ELEMENTS_FEATURE = "";
+    public static final String RESTART_ELEMENTS_FEATURE = "restart-elements";
 
     /**
      * A value of "true" indicates that the parser will transmit whitespace in element-only content via the SAX ignorableWhitespace callback. Normally
      * this is not done, because HTML is an SGML application and SGML suppresses such whitespace.
      **/
-    public static final String IGNORABLE_WHITESPACE_FEATURE = "";
+    public static final String IGNORABLE_WHITESPACE_FEATURE = "ignorable-whitespace";
 
     /**
      * A value of "true" indicates that the parser will treat CDATA elements specially. Normally true, since the input is by default HTML.
      **/
-    public static final String CDATA_ELEMENTS_FEATURE = "";
+    public static final String CDATA_ELEMENTS_FEATURE = "cdata-elements";
 
     /**
      * Used to see some syntax events that are essential in some applications: comments, CDATA delimiters, selected general entity inclusions, and the
@@ -221,17 +221,17 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
     /**
      * Specifies the Scanner object this Parser uses.
      **/
-    public static final String SCANNER_PROPERTY = "";
+    public static final String SCANNER_PROPERTY = "scanner";
 
     /**
      * Specifies the Schema object this Parser uses.
      **/
-    public static final String SCHEMA_PROPERTY = "";
+    public static final String SCHEMA_PROPERTY = "schema";
 
     /**
      * Specifies the AutoDetector (for encoding detection) this Parser uses.
      **/
-    public static final String AUTO_DETECTOR_PROPERTY = "";
+    public static final String AUTO_DETECTOR_PROPERTY = "auto-detector";
 
     // Due to sucky Java order of initialization issues, these
     // entries are maintained separately from the initial values of

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.lafa.tagchowder</groupId>
     <artifactId>tagchowder</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/lafaspot/tagchowder</url>
     <description>Parent POM file for tagchowder project</description>


### PR DESCRIPTION
Fix generate-sources output location, in order to not have replacer.* in package name.
Add default value for static values in Parser (required for tika)

@lafa 